### PR TITLE
update cookiecutter.json - BSD as default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,12 @@
     "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
     "pypi_username": "{{ cookiecutter.github_username }}",
     "version": "0.1.0",
-    "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]
-  }
+    "open_source_license": [
+        "BSD license",
+        "MIT license",
+        "ISC license",
+        "Apache Software License 2.0",
+        "GNU General Public License v3",
+        "Not open source"
+    ]
+}


### PR DESCRIPTION
- as per https://paper.dropbox.com/doc/Python-Package-Maintenance-Guidelines--BcbS1tOocmhxg78lje4U19RWAg-ZDYOJ7mgnhaC47Tzu8Jn0
- BSD is now the preferred default license