### PR TITLE
Rename master branches to main

### DIFF
--- a/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/config.yml
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
         keys:
           - node-modules-{% raw %}{{ .Branch }}-{{ checksum "package-lock.json" }}{% endraw %}
           - node-modules-{% raw %}{{ .Branch }}-{% endraw %}
-          - node-modules-master-
+          - node-modules-main-
 
       - run: npm install
       - run: npm run lint
@@ -37,8 +37,8 @@ jobs:
 
       - type: cache-restore
         keys:
-         - pip-{% raw %}{{ .Branch }}-{% endraw %}
-         - pip-master-
+          - pip-{% raw %}{{ .Branch }}-{% endraw %}
+          - pip-main-
 
       - run: pip install -e .[testing]
 
@@ -66,20 +66,20 @@ jobs:
           command: python ./.circleci/report_nightly_build_failure.py
 
 workflows:
-    version: 2
-    test:
-      jobs:
-        - flake8
-        - prettier
-        - test
+  version: 2
+  test:
+    jobs:
+      - flake8
+      - prettier
+      - test
 
-    nightly:
-      jobs:
-        - nightly-wagtail-test
-      triggers:
-        - schedule:
-            cron: "0 0 * * *"
-            filters:
-              branches:
-                only:
-                  - master
+  nightly:
+    jobs:
+      - nightly-wagtail-test
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/trigger-nightly-build.sh
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/trigger-nightly-build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Triggers a test run against the master version of Wagtail
+# Triggers a test run against the main version of Wagtail
 
 # This job will is scheduled in the config.yml, this script is here to help test the job
 
 curl -u ${CIRCLE_API_USER_TOKEN}: \
      -d build_parameters[CIRCLE_JOB]=nightly-wagtail-test \
-     https://circleci.com/api/v1.1/project/github/wagtail/wagtail-{{ cookiecutter.project_name_kebab }}/tree/master
+     https://circleci.com/api/v1.1/project/github/wagtail/wagtail-{{ cookiecutter.project_name_kebab }}/tree/main

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/.github/workflows/test.yml
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
       - 'stable/**'
 
   pull_request:

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/tox.ini
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = python{3.7,3.8,3.9}-django{3.0,3.1,3.2,master}-wagtail{2.14,2.15,master}-{sqlite,postgres}
+envlist = python{3.7,3.8,3.9}-django{3.0,3.1,3.2,main}-wagtail{2.14,2.15,main}-{sqlite,postgres}
 
 [flake8]
 # E501: Line too long
@@ -26,12 +26,12 @@ deps =
     django3.1: Django>=3.1,<3.2
     django3.2: Django>=3.2,<4.0
 
-    djangomaster: git+https://github.com/django/django.git@master#egg=Django
-    djangomaster: git+https://github.com/wagtail/django-modelcluster.git
+    djangomain: git+https://github.com/django/django.git@main#egg=Django
+    djangomain: git+https://github.com/wagtail/django-modelcluster.git
 
     wagtail2.14: wagtail>=2.14,<2.15
     wagtail2.15: wagtail==2.15rc1
-    wagtailmaster: git+https://github.com/wagtail/wagtail.git
+    wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6
 


### PR DESCRIPTION
Both Django and Wagtail have now renamed their master branches to main.

Also removed all references to master from generated CI configs as I expect any future new packages to use main for the default branch.