### PR TITLE
Fixes for whitespace and project/badge URLs

### DIFF
--- a/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/trigger-nightly-build.sh
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/.circleci/trigger-nightly-build.sh
@@ -5,4 +5,4 @@
 
 curl -u ${CIRCLE_API_USER_TOKEN}: \
      -d build_parameters[CIRCLE_JOB]=nightly-wagtail-test \
-     https://circleci.com/api/v1.1/project/github/wagtail/wagtail-{{ cookiecutter.project_name_kebab }}/tree/main
+     https://circleci.com/api/v1.1/project/github/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/tree/main

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/LICENSE
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/LICENSE
@@ -1,5 +1,5 @@
-{# Copied from https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/LICENSE #}
-{% if cookiecutter.open_source_license == 'MIT license' -%}
+{#- Copied from https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/LICENSE -#}
+{%- if cookiecutter.open_source_license == 'MIT license' -%}
 MIT License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -21,8 +21,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.open_source_license == 'BSD license' %}
-
+{%- elif cookiecutter.open_source_license == 'BSD license' -%}
 BSD License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -52,7 +51,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-{% elif cookiecutter.open_source_license == 'ISC license' -%}
+{%- elif cookiecutter.open_source_license == 'ISC license' -%}
 ISC License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -60,7 +59,7 @@ Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-{% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
+{%- elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
 Apache Software License 2.0
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -76,7 +75,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-{% elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
+{%- elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/README.md
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/README.md
@@ -4,13 +4,14 @@
 
 {% if cookiecutter.open_source_license == 'MIT license' -%}
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-{% elif cookiecutter.open_source_license == 'BSD license' %}
+{%- elif cookiecutter.open_source_license == 'BSD license' -%}
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-{% elif cookiecutter.open_source_license == 'ISC license' -%}
- [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
-{% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-{% elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
+{%- elif cookiecutter.open_source_license == 'ISC license' -%}
+[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
+{%- elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+{%- elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
+[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://opensource.org/licenses/GPL-3.0)
 {% endif %}
 [![PyPI version](https://badge.fury.io/py/{{ cookiecutter.project_name_kebab }}.svg)](https://badge.fury.io/py/{{ cookiecutter.project_name_kebab }})
 [![{{ cookiecutter.project_name }} CI](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/actions/workflows/test.yml/badge.svg)](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/actions/workflows/test.yml)

--- a/wagtail-{{ cookiecutter.project_name_kebab }}/README.md
+++ b/wagtail-{{ cookiecutter.project_name_kebab }}/README.md
@@ -13,16 +13,16 @@
 {%- elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://opensource.org/licenses/GPL-3.0)
 {% endif %}
-[![PyPI version](https://badge.fury.io/py/{{ cookiecutter.project_name_kebab }}.svg)](https://badge.fury.io/py/{{ cookiecutter.project_name_kebab }})
-[![{{ cookiecutter.project_name }} CI](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/actions/workflows/test.yml/badge.svg)](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/actions/workflows/test.yml)
+[![PyPI version](https://badge.fury.io/py/wagtail-{{ cookiecutter.project_name_kebab }}.svg)](https://badge.fury.io/py/wagtail-{{ cookiecutter.project_name_kebab }})
+[![{{ cookiecutter.project_name }} CI](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/actions/workflows/test.yml/badge.svg)](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/actions/workflows/test.yml)
 
 ## Links
 
-- [Documentation](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/blob/main/README.md)
-- [Changelog](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/blob/main/CHANGELOG.md)
-- [Contributing](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/blob/main/CHANGELOG.md)
-- [Discussions](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/discussions)
-- [Security](https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}/security)
+- [Documentation](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/blob/main/README.md)
+- [Changelog](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/blob/main/CHANGELOG.md)
+- [Discussions](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/discussions)
+- [Security](https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}/security)
 
 ## Supported versions
 


### PR DESCRIPTION
This should really be at least 2 PRs, but I wanted to do several things that changed all the same lines so I've made it 1 PR just to cut down on merge conflict resolution.

The first change here is mainly just minor whitespace fixes. Due to the type of template tags used the LICENSE and README files get generated with some spurious whitespace in various places.
I've also added a badge for the `cookiecutter.open_source_license == 'GNU General Public License v3'` case and fixed a bit of missing alt text.

The second one is I've changed everything to consistently assume:

1. The Github repo URL will be `https://github.com/{{ cookiecutter.github_username }}/wagtail-{{ cookiecutter.project_name_kebab }}` not `https://github.com/wagtail/{{ cookiecutter.project_name_kebab }}` (i.e: `https://github.com/fredbloggs/wagtail-localize` not `https://github.com/wagtail/localize`)
2. The PyPI project will be called `wagtail-{{ cookiecutter.project_name_kebab }}` not `{{ cookiecutter.project_name_kebab }}` (i.e: `wagtail-localize` not `localize`)

..although if you prefer, we could assume `https://github.com/wagtail/wagtail-{{ cookiecutter.project_name_kebab }}` everywhere and drop `github_username` from the cookiecutter variables too if you prefer. Either way, this closes https://github.com/wagtail/cookiecutter-wagtail-package/issues/27