### PR TITLE
drop version variable

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,6 @@
     "full_name": "Karl Hobley",
     "email": "karl@kaed.uk",
     "github_username": "kaedroho",
-    "version": "0.1.0",
     "node_version": "16",
     "open_source_license": [
         "BSD license",

--- a/{{ cookiecutter.__project_name_kebab }}/CHANGELOG.md
+++ b/{{ cookiecutter.__project_name_kebab }}/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [{{ cookiecutter.version }}] - {% now 'local', '%Y-%m-%d' %}
+## [0.1.0] - {% now 'local', '%Y-%m-%d' %}
 
 ### Added
 

--- a/{{ cookiecutter.__project_name_kebab }}/package.json
+++ b/{{ cookiecutter.__project_name_kebab }}/package.json
@@ -1,6 +1,6 @@
 {
   "name": "{{ cookiecutter.__project_name_kebab }}",
-  "version": "{{ cookiecutter.version }}",
+  "version": "0.1.0",
   "description": "{{ cookiecutter.project_short_description }}",
   "main": "{{ cookiecutter.__project_name_snake }}/static_src/main.tsx",
   "scripts": {


### PR DESCRIPTION
Closes #33

The other option would be to find a way to validate `cookiecutter.version` against a regex to make sure it is `x.y.z`, then split it out to populate the tuple in https://github.com/wagtail/cookiecutter-wagtail-package/blob/a4e7cf574ab711dfd810310d143bbc98eb694e1e/%7B%7B%20cookiecutter.__project_name_kebab%20%7D%7D/%7B%7B%20cookiecutter.__project_name_snake%20%7D%7D/__init__.py#L4
Tbh though, I think just dropping it as a param and hard-coding `0.1.0` is a reasonable approach.