### PR TITLE
Update python ecosystem dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.11'
 
       - uses: actions/download-artifact@v3
-        # Restore the rendered areifact to a directory outside the repo checkout.
+        # Restore the rendered artifact to a directory outside the repo checkout.
         # Even if we invoke pre-commit from in a subdirectory
         # it tries to lint the whole repo including the raw templates.
         with:

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
@@ -35,16 +35,18 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9']
-        django: ['3.2']
-        wagtail: ['2.15', '4.0', '4.1']
-        include:
-          - python: '3.10'
-            django: '4.1'
+        python: ['3.8', '3.9', '3.10', '3.11']
+        django: ['3.2', '4.0', '4.1', '4.2']
+        wagtail: ['4.1', '4.2', '5.0', '5.1']
+        exclude:
+          - django: '4.0'
+            wagtail: '5.0'
+          - django: '4.0'
+            wagtail: '5.1'
+          - django: '4.2'
             wagtail: '4.1'
-          - python: '3.11'
-            django: '4.1'
-            wagtail: '4.1'
+          - django: '4.2'
+            wagtail: '4.2'
 
     steps:
       - uses: actions/checkout@v3
@@ -67,20 +69,19 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9']
-        django: ['3.2']
-        wagtail: ['2.15', '4.0', '4.1']
+        python: ['3.8', '3.9', '3.10', '3.11']
+        django: ['3.2', '4.0', '4.1', '4.2']
+        wagtail: ['4.1', '4.2', '5.0', '5.1']
         experimental: [false]
-        include:
-          - python: '3.9'
-            django: '4.0'
-            wagtail: '4.0'
-          - python: '3.10'
-            django: '4.0'
+        exclude:
+          - django: '4.0'
+            wagtail: '5.0'
+          - django: '4.0'
+            wagtail: '5.1'
+          - django: '4.2'
             wagtail: '4.1'
-          - python: '3.11'
-            django: '4.1'
-            wagtail: '4.1'
+          - django: '4.2'
+            wagtail: '4.2'
 
     services:
       postgres:

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.8', '3.9']
         django: ['3.2']
         wagtail: ['2.15', '4.0', '4.1']
         include:
@@ -67,7 +67,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.8', '3.9']
         django: ['3.2']
         wagtail: ['2.15', '4.0', '4.1']
         experimental: [false]

--- a/{{ cookiecutter.__project_name_kebab }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__project_name_kebab }}/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3
@@ -31,7 +31,7 @@ repos:
       - id: isort
   - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/{{ cookiecutter.__project_name_kebab }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__project_name_kebab }}/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
           - 'eslint-plugin-react@7.32.1'
           - 'eslint-plugin-react-hooks@4.6.0'
           - '@typescript-eslint/eslint-plugin@5.49.0'
-          - '@typescript-eslint/parser@5.49.0'
+          - '@typescript-eslint/parser@6.7.0'
           - '@wagtail/eslint-config-wagtail@0.4.0'
         files: \.(js|jsx|ts|tsx)$
         types: [file]

--- a/{{ cookiecutter.__project_name_kebab }}/README.md
+++ b/{{ cookiecutter.__project_name_kebab }}/README.md
@@ -85,7 +85,7 @@ Now you can run tests as shown below:
 tox
 ```
 
-or, you can run them for a specific environment `tox -e python3.8-django3.2-wagtail2.15` or specific test
-`tox -e python3.9-django3.2-wagtail2.15-sqlite {{ cookiecutter.__project_name_kebab }}.tests.test_file.TestClass.test_method`
+or, you can run them for a specific environment `tox -e python3.11-django4.2-wagtail5.1` or specific test
+`tox -e python3.11-django4.2-wagtail5.1-sqlite {{ cookiecutter.__project_name_kebab }}.tests.test_file.TestClass.test_method`
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.

--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -37,15 +37,17 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 4",
+    "Framework :: Wagtail :: 5",
 ]
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "Django>=3.0,<4.2",
-    "Wagtail>=2.15,<5.0"
+    "Django>=3.2",
+    "Wagtail>=4.1,<6.0"
 ]
 [project.optional-dependencies]
 testing = [

--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -51,8 +51,8 @@ dependencies = [
 ]
 [project.optional-dependencies]
 testing = [
-    "dj-database-url==1.2.0",
-    "pre-commit>=2.21.0,<3.0"
+    "dj-database-url==2.1.0",
+    "pre-commit==3.4.0"
 ]
 
 [project.urls]

--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -42,6 +41,7 @@ classifiers = [
     "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 4",
 ]
+requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "Django>=3.0,<4.2",

--- a/{{ cookiecutter.__project_name_kebab }}/testmanage.py
+++ b/{{ cookiecutter.__project_name_kebab }}/testmanage.py
@@ -56,7 +56,7 @@ def runtests():
     try:
         execute_from_command_line(argv)
     finally:
-        from wagtail.tests.settings import MEDIA_ROOT, STATIC_ROOT
+        from wagtail.test.settings import MEDIA_ROOT, STATIC_ROOT
 
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)
         shutil.rmtree(MEDIA_ROOT, ignore_errors=True)

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -3,9 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.7,3.8,3.9}-django{3.2}-wagtail{2.15,4.0,4.1}-{sqlite,postgres}
+    python{3.8,3.9}-django{3.2}-wagtail{2.15,4.0,4.1}-{sqlite,postgres}
     python{3.10}-django{3.2}-wagtail{2.15,4.0,4.1,main}-{sqlite,postgres}
-    python{3.7,3.8,3.9,3.10}-django{4.0}-wagtail{4.0,4.1,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{4.0}-wagtail{4.0,4.1,main}-{sqlite,postgres}
     python{3.8,3.9,3.10,3.11}-django{4.1,main}-wagtail{4.1,main}-{sqlite,postgres}
 
 [testenv]
@@ -13,7 +13,6 @@ install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run testmanage.py test --deprecation all {posargs: -v 2}
 
 basepython =
-    python3.7: python3.7
     python3.8: python3.8
     python3.9: python3.9
     python3.10: python3.10

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -3,10 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9}-django{3.2}-wagtail{2.15,4.0,4.1}-{sqlite,postgres}
-    python{3.10}-django{3.2}-wagtail{2.15,4.0,4.1,main}-{sqlite,postgres}
-    python{3.8,3.9,3.10}-django{4.0}-wagtail{4.0,4.1,main}-{sqlite,postgres}
-    python{3.8,3.9,3.10,3.11}-django{4.1,main}-wagtail{4.1,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{3.2,4.0,4.1}-wagtail{4.1,4.2}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2,main}-wagtail{5.0,5.1,main}-{sqlite,postgres}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -24,11 +22,13 @@ deps =
     django3.2: Django>=3.2,<4.0
     django4.0: Django>=4.0,<4.1
     django4.1: Django>=4.1,<4.2
+    django4.2: Django>=4.2,<4.3
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
-    wagtail2.15: wagtail>=2.15,<2.16
-    wagtail4.0: wagtail>=4.0,<4.1
-    wagtail4.1: wagtail>=4.1,<5.0
+    wagtail4.1: wagtail>=4.1,<4.2
+    wagtail4.2: wagtail>=4.2,<4.3
+    wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/test/settings.py
+++ b/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/test/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = [
     "wagtail.contrib.routable_page",
     "wagtail.contrib.styleguide",
     "wagtail.sites",
-    "wagtail.core",
+    "wagtail",
     "taggit",
     "rest_framework",
     "django.contrib.admin",

--- a/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/test/urls.py
+++ b/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/test/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
+from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 

--- a/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/wagtail_hooks.py
+++ b/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 from django.views.i18n import JavaScriptCatalog
-from wagtail.core import hooks
+from wagtail import hooks
 
 
 @hooks.register("register_admin_urls")


### PR DESCRIPTION
PR #51 was opened and then abandoned. It has not been touched in some months.

While well intentioned, one of the problems with that PR is it tried to a lot of things at once. It was:

- Updating python and related packages
- Updating javascript packages
- Implementing feature https://github.com/wagtail/cookiecutter-wagtail-package/issues/14
- Migrating linters from black/isort/flake8 to ruff

Those weren't necessarily bad or wrong things to do, but doing them all at once made it hard to review and also hard to pick up the PR and update it or get it finished.

In this PR, I have intentionally reduced the scope. All I am doing here is updating python and python ecosystem-related packages. I am intentionally not touching anything node/javascript related in this PR and I'm sticking with black/isort/flake8. Hopefully this will make it easier to get this reviewed and merged. We can look at the other issues in further more tightly scoped PRs

Closes https://github.com/wagtail/cookiecutter-wagtail-package/issues/50