### PR TITLE
Remove django main from tox matrix

### DIFF
--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -4,7 +4,7 @@ usedevelop = True
 
 envlist =
     python{3.8,3.9,3.10,3.11}-django{3.2,4.0,4.1}-wagtail{4.1,4.2}-{sqlite,postgres}
-    python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2,main}-wagtail{5.0,5.1,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
Currently if you make a new project from this template, your first CI build will fail with

```
ERROR: ResolutionImpossible

The conflict is caused by:
    The user requested django 5.1.dev20230921061051 (from git+https://github.com/django/django.git@main)
    wagtail 5.1.1 depends on Django<4.3 and >=3.2
    The user requested django 5.1.dev20230921061051 (from git+https://github.com/django/django.git@main)
    wagtail 5.1 depends on Django<4.3 and >=3.2
```

when it tries to test django main against any wagtail version, including wagtail main.

As a plugin author, there is no way you can change your code to fix this.

I feel like including this sets users up for failure.. At some point, your build is going to start failing due to upstream externalities you can't account for in your plugin.

Maybe testing against django `main` should be an allowed failure, or go into the nightly job or something? I don't think it should be a requirement for pushes and PRs though.