### PR TITLE
use trusted publisher workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This creates Github Workflows for:
 
 - Running tests and linters on pushes and pull requests
 - Running tests nightly against latest Wagtail version
-- Pushing packages to PyPI when GitHub releases are created
+- Pushing packages to PyPI when GitHub releases are created. This requires two additional setup steps before it can be used:
+  - Create a pending publisher in PyPI: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
+  - Create an environment called "publish" in GitHub: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#creating-an-environment
 
 ### Frontend tooling
 

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -33,9 +33,7 @@ jobs:
         run: python -m flit build
 
       - name: Publish to PyPI
-        env:
-          FLIT_USERNAME: '__token__'
-          FLIT_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          FLIT_INDEX_URL: https://upload.pypi.org/legacy/
-        run: python -m flit publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
 {%- endraw %}

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # to fetch code (actions/checkout)
-      id-token: write  # required for trusted publishing
+      id-token: write # required for trusted publishing
     environment: publish
     steps:
       - uses: actions/checkout@v3

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: read # to fetch code (actions/checkout)
+      contents: none
       id-token: write # required for trusted publishing
     environment: publish
     steps:

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -7,12 +7,13 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      id-token: write  # required for trusted publishing
+    environment: publish
     steps:
       - uses: actions/checkout@v3
         with:

--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/publish.yml
@@ -8,12 +8,10 @@ on:
     types: [published]
 
 jobs:
-  build_and_publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read # to fetch code (actions/checkout)
-      id-token: write # required for trusted publishing
-    environment: publish
     steps:
       - uses: actions/checkout@v3
         with:
@@ -33,8 +31,23 @@ jobs:
       - name: Build
         run: python -m flit build
 
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      id-token: write # required for trusted publishing
+    environment: publish
+    steps:
+      - uses: actions/download-artifact@v3
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages-dir: artifact/
           print-hash: true
 {%- endraw %}


### PR DESCRIPTION
closes #61

This PR switches the 'publish' workflow we provide to use the trusted publisher workflow instead of a token secret.

As well as the security benefits, this also allows the publish workflow to initially _create_ your package. You don't have to release the first version manually and then generate a token to use for subsequent releases.

Side note: I will also update our internal intranet docs about publishing once we merge this