### PR TITLE
don't pass token to pre-commit

### DIFF
--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           python-version: '3.8'
       - uses: pre-commit/action@v3.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-sqlite:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Token is not a valid param to pass `pre-commit/action@v3.0.0`
This was removed in https://github.com/pre-commit/action/pull/164 and logs a warning if passed:

![Screenshot at 2023-10-12 20-26-09](https://github.com/wagtail/cookiecutter-wagtail-package/assets/6025893/92ade3eb-4029-44ba-9266-a37ced240d52)
