### PR TITLE
Use cookiecutter options pattern for licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+.venv
+.vscode

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,5 +20,13 @@
         "GNU General Public License v3",
         "Not open source"
     ],
+    "__license_options_pypi": {
+        "BSD 3-Clause license": "License :: OSI Approved :: BSD License",
+        "MIT license": "License :: OSI Approved :: MIT License",
+        "ISC license": "License :: OSI Approved :: ISC License (ISCL)",
+        "Apache Software License 2.0": "License :: OSI Approved :: Apache Software License",
+        "GNU General Public License v3": "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Not open source": "License :: Other/Proprietary License"
+    },
     "use_frontend": "y"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -36,5 +36,13 @@
         "GNU General Public License v3": "GPL-3.0-only",
         "Not open source": "UNLICENSED"
     },
+    "__license_options_readme_badges": {
+        "BSD 3-Clause license": "[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)",
+        "MIT license": "[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)",
+        "ISC license": "[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)",
+        "Apache Software License 2.0": "[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)",
+        "GNU General Public License v3": "[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://opensource.org/licenses/GPL-3.0)",
+        "Not open source": ""
+    },
     "use_frontend": "y"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -28,5 +28,13 @@
         "GNU General Public License v3": "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Not open source": "License :: Other/Proprietary License"
     },
+    "__license_options_npm": {
+        "BSD 3-Clause license": "BSD-3-Clause",
+        "MIT license": "MIT",
+        "ISC license": "ISC",
+        "Apache Software License 2.0": "Apache-2.0",
+        "GNU General Public License v3": "GPL-3.0-only",
+        "Not open source": "UNLICENSED"
+    },
     "use_frontend": "y"
 }

--- a/{{ cookiecutter.__project_name_kebab }}/.gitignore
+++ b/{{ cookiecutter.__project_name_kebab }}/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 /.coverage
 /htmlcov
 /.tox
+/.venv
 /venv
 /.vscode
 /site

--- a/{{ cookiecutter.__project_name_kebab }}/README.md
+++ b/{{ cookiecutter.__project_name_kebab }}/README.md
@@ -2,17 +2,7 @@
 
 {{ cookiecutter.project_short_description }}
 
-{% if cookiecutter.open_source_license == 'MIT license' -%}
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-{%- elif cookiecutter.open_source_license == 'BSD 3-Clause license' -%}
-[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-{%- elif cookiecutter.open_source_license == 'ISC license' -%}
-[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
-{%- elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-{%- elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://opensource.org/licenses/GPL-3.0)
-{% endif %}
+{{ cookiecutter.__license_options_readme_badges[cookiecutter.open_source_license] }}
 [![PyPI version](https://badge.fury.io/py/{{ cookiecutter.__project_name_kebab }}.svg)](https://badge.fury.io/py/{{ cookiecutter.__project_name_kebab }})
 [![{{ cookiecutter.project_name }} CI](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.__project_name_kebab }}/actions/workflows/test.yml/badge.svg)](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.__project_name_kebab }}/actions/workflows/test.yml)
 

--- a/{{ cookiecutter.__project_name_kebab }}/package.json
+++ b/{{ cookiecutter.__project_name_kebab }}/package.json
@@ -8,7 +8,7 @@
     "build": "webpack --config ./webpack.config.js --mode production"
   },
   "author": "{{ cookiecutter.full_name }}",
-  "license": "{% if cookiecutter.open_source_license == 'MIT license' -%}MIT{% elif cookiecutter.open_source_license == 'BSD 3-Clause license' %}BSD-3-Clause{% elif cookiecutter.open_source_license == 'ISC license' -%}ISC{% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}Apache-2.0{% elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}GPL-3.0-only{% endif %}",
+  "license": "{{ cookiecutter.__license_options_npm[cookiecutter.open_source_license] }}",
   "devDependencies": {
     "@svgr/webpack": "^6.2.1",
     "@types/react": "^16.8.19",

--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -11,19 +11,7 @@ license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    {% if cookiecutter.open_source_license == 'MIT license' -%}
-    "License :: OSI Approved :: MIT License",
-    {%- elif cookiecutter.open_source_license == 'BSD 3-Clause license' -%}
-    "License :: OSI Approved :: BSD License",
-    {%- elif cookiecutter.open_source_license == 'ISC license' -%}
-    "License :: OSI Approved :: ISC License (ISCL)",
-    {%- elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
-    License :: OSI Approved :: Apache Software License",
-    {%- elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    {%- elif cookiecutter.open_source_license == 'Not open source' -%}
-    "License :: Other/Proprietary License",
-    {%- endif %}
+    "{{ cookiecutter.__license_options_pypi[cookiecutter.open_source_license] }}",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
The other day I stumbled upon https://daniel.feldroy.com/posts/2023-04-cookiecutter-options-pattern and thought this would great for the LICENSE conditionals

Used "UNLICENSED" for the "Not open source" license for npm as per https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license, but perhaps that could just be an empty string