### PR TITLE
update python/django/wagtail versions

### DIFF
--- a/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab }}/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     services:
       postgres:

--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -19,15 +19,11 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
 ]
@@ -35,7 +31,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "Django>=3.2",
-    "Wagtail>=4.1,<6.0"
+    "Wagtail>=4.1"
 ]
 [project.optional-dependencies]
 testing = [

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django{3.2,4.0,4.1}-wagtail{4.1,4.2}-{sqlite,postgres}
-    python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{3.2}-wagtail{4.1}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{3.2,4.2}-wagtail{5.1,5.2,main}-{sqlite,postgres}
+    python{3.12}-django{4.2}-wagtail{5.2,main}-{sqlite,postgres}
 
 [gh-actions]
 python =
@@ -12,6 +13,7 @@ python =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
+    3.12: python3.12
 
 [gh-actions:env]
 DB =
@@ -27,20 +29,18 @@ basepython =
     python3.9: python3.9
     python3.10: python3.10
     python3.11: python3.11
+    python3.12: python3.12
 
 deps =
     coverage
 
     django3.2: Django>=3.2,<4.0
-    django4.0: Django>=4.0,<4.1
-    django4.1: Django>=4.1,<4.2
     django4.2: Django>=4.2,<4.3
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail4.1: wagtail>=4.1,<4.2
-    wagtail4.2: wagtail>=4.2,<4.3
-    wagtail5.0: wagtail>=5.0,<5.1
     wagtail5.1: wagtail>=5.1,<5.2
+    wagtail5.2: wagtail>=5.2,<5.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -36,7 +36,6 @@ deps =
 
     django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<4.3
-    djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail5.1: wagtail>=5.1,<5.2

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -4,8 +4,8 @@ usedevelop = True
 
 envlist =
     python{3.8,3.9,3.10,3.11}-django{3.2}-wagtail{4.1}-{sqlite,postgres}
-    python{3.8,3.9,3.10,3.11}-django{3.2,4.2}-wagtail{5.1,5.2,main}-{sqlite,postgres}
-    python{3.12}-django{4.2}-wagtail{5.2,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{3.2,4.2}-wagtail{5.1,5.2}-{sqlite,postgres}
+    python{3.12}-django{4.2}-wagtail{5.2}-{sqlite,postgres}
 
 [gh-actions]
 python =
@@ -41,7 +41,6 @@ deps =
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6
 

--- a/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/test/settings.py
+++ b/{{ cookiecutter.__project_name_kebab }}/{{ cookiecutter.__project_name_snake }}/test/settings.py
@@ -45,7 +45,6 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.api.v2",
-    "wagtail.contrib.modeladmin",
     "wagtail.contrib.routable_page",
     "wagtail.contrib.styleguide",
     "wagtail.sites",


### PR DESCRIPTION
Closes #66

As well as adding the shiny new things, I've taken the opportunity to remove some django/wagtail version which are out of support from the tox matrix, classifiers, etc. I also dropped django 4.1. Technically 4.1 still receives security upgrades for another 2 weeks, but while I've got a bit of time to do this, I think we can just drop it now.