### PR TITLE
Update django/wagtail support

### DIFF
--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "Django>=4.2",
-    "Wagtail>=5.1"
+    "Wagtail>=5.2"
 ]
 [project.optional-dependencies]
 testing = [

--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -21,17 +21,16 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
 ]
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "Django>=3.2",
-    "Wagtail>=4.1"
+    "Django>=4.2",
+    "Wagtail>=5.1"
 ]
 [project.optional-dependencies]
 testing = [

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -3,9 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django{3.2}-wagtail{4.1}-{sqlite,postgres}
-    python{3.8,3.9,3.10,3.11}-django{3.2,4.2}-wagtail{5.1,5.2}-{sqlite,postgres}
-    python{3.12}-django{4.2}-wagtail{5.2}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django{4.2}-wagtail{5.1}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2}-{sqlite,postgres}
 
 [gh-actions]
 python =
@@ -34,8 +34,8 @@ basepython =
 deps =
     coverage
 
-    django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<4.3
+    django5.0: Django>=5.0,<5.1
 
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail5.1: wagtail>=5.1,<5.2

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -3,7 +3,6 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django{4.2}-wagtail{5.1}-{sqlite,postgres}
     python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2}-{sqlite,postgres}
     python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2}-{sqlite,postgres}
 
@@ -37,8 +36,6 @@ deps =
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
 
-    wagtail4.1: wagtail>=4.1,<4.2
-    wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
 
     postgres: psycopg2>=2.6


### PR DESCRIPTION
Closes https://github.com/wagtail/cookiecutter-wagtail-package/issues/71

In this PR I have:

- Added Django 5.0 to test matrix
- Dropped Django 3.2, as per discussion in https://github.com/wagtail/cookiecutter-wagtail-package/issues/71
- Also dropped Wagtail 4.1. Dropping Django 3.2 also implies dropping wagtail 4.1 because that is the only version of Django it can run on :) Wagtail 4.2 still receives security updates up until the end of Jan 2024, but `Django>=4.2, Wagtail>=5.1` seems like a reasonable support target for a wagtail project which is being started new today.