### PR TITLE
Add Wagtail 6 to testing matrix

### DIFF
--- a/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab }}/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
 ]
 requires-python = ">=3.8"
 dynamic = ["version"]

--- a/{{ cookiecutter.__project_name_kebab }}/tox.ini
+++ b/{{ cookiecutter.__project_name_kebab }}/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2}-{sqlite,postgres}
-    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11,3.12}-django{4.2}-wagtail{5.2,6.0}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.0}-{sqlite,postgres}
 
 [gh-actions]
 python =
@@ -37,6 +37,7 @@ deps =
     django5.0: Django>=5.0,<5.1
 
     wagtail5.2: wagtail>=5.2,<5.3
+    wagtail6.0: wagtail>=5.2,<5.3
 
     postgres: psycopg2>=2.6
 


### PR DESCRIPTION
The default testing matrix only includes Wagtail 5.2. I wonder if this should be testing against dev versions of Wagtail too? It would help surface compatibility issues sooner.

Here's a successful test run. It's based off the https://github.com/wagtail/cookiecutter-wagtail-package/pull/76 branch.