### PR TITLE
Add basic translation support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,35 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     permissions: {}
+  compilemessages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install gettext to compile translation files
+        run: sudo apt-get install -y gettext
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # Prevent cache poisoning by disabling cache.
+        with:
+          enable-cache: false
+      - run: uv run ../demo/manage.py compilemessages
+        # Need to be in the `src` directory, otherwise compilemessages
+        # will try to compile other apps too
+        working-directory: src
+      - name: Upload compiled message catalogs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: compiled-message-catalogs
+          if-no-files-found: error
+          # Save compiled message catalogs to the same relative path so they can
+          # be easily merged back into the source tree in the next job
+          path: |
+            ./src/my_project_name/**/*.mo
   build:
-    needs: test
+    needs: [test, compilemessages]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,6 +53,12 @@ jobs:
         # Prevent cache poisoning by disabling cache.
         with:
           enable-cache: false
+      - name: Download compiled message catalogs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          # Places catalogs back in the same relative path as when they were uploaded
+          # meaning they will be in the correct location for packaging
+          name: compiled-message-catalogs
       - run: uv build
       # Smoke tests with ready-to-publish package.
       - run: uv run --isolated --no-project --with dist/*.whl pytest

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ __pycache__/
 /node_modules
 /test-static
 /test-media
+*.mo
 
 demo/media

--- a/demo/demo/settings/base.py
+++ b/demo/demo/settings/base.py
@@ -122,6 +122,10 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
+LOCALE_PATHS = [
+    PROJECT_DIR / "locale",
+]
+
 TIME_ZONE = "UTC"
 
 USE_I18N = True

--- a/justfile
+++ b/justfile
@@ -82,3 +82,9 @@ shell:
 
 # Run the demo application.
 demo: migrate load_initial_data runserver
+
+# Extract messages for translation
+makemessages *args:
+    @# Pass any additional arguments to the `makemessages` command, e.g. `just messages -l=es`.
+    @# default to `--all` if no arguments are provided.
+    uv run ./demo/manage.py makemessages {% raw %}{{ if args != "" { args } else { "--all" } }}{% endraw %}

--- a/justfile
+++ b/justfile
@@ -88,3 +88,6 @@ makemessages *args:
     @# Pass any additional arguments to the `makemessages` command, e.g. `just messages -l=es`.
     @# default to `--all` if no arguments are provided.
     uv run ./demo/manage.py makemessages {% raw %}{{ if args != "" { args } else { "--all" } }}{% endraw %}
+
+compilemessages:
+    cd src && uv run ../demo/manage.py compilemessages

--- a/src/my_project_name/locale/ar/LC_MESSAGES/django.po
+++ b/src/my_project_name/locale/ar/LC_MESSAGES/django.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-14 09:55+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+#: src/my_project_name/templates/my_project_name/admin/my_project_name_summary.html:4
+#, python-format
+msgid "Hello, I am a panel from %(project_name)s"
+msgstr "مرحبًا، أنا لوحة من %(project_name)s"

--- a/src/my_project_name/locale/es/LC_MESSAGES/django.po
+++ b/src/my_project_name/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-14 09:55+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+#: src/my_project_name/templates/my_project_name/admin/my_project_name_summary.html:4
+#, python-format
+msgid "Hello, I am a panel from %(project_name)s"
+msgstr "Hola, soy un panel de %(project_name)s"

--- a/src/my_project_name/locale/fr/LC_MESSAGES/django.po
+++ b/src/my_project_name/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-14 09:55+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: src/my_project_name/templates/my_project_name/admin/my_project_name_summary.html:4
+#, python-format
+msgid "Hello, I am a panel from %(project_name)s"
+msgstr "Bonjour, je suis un panneau de %(project_name)s"

--- a/src/my_project_name/locale/nl/LC_MESSAGES/django.po
+++ b/src/my_project_name/locale/nl/LC_MESSAGES/django.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-14 09:55+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: src/my_project_name/templates/my_project_name/admin/my_project_name_summary.html:4
+#, python-format
+msgid "Hello, I am a panel from %(project_name)s"
+msgstr "Hallo, ik ben een paneel van %(project_name)s"

--- a/src/my_project_name/templates/my_project_name/admin/my_project_name_summary.html
+++ b/src/my_project_name/templates/my_project_name/admin/my_project_name_summary.html
@@ -1,5 +1,5 @@
-    {% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags %}
 <li>
     {% icon name="cog" %}
-    <span>{% trans "Demo: My project name" %}</span>
+    <span>{% blocktrans with project_name="My project name" trimmed %}Hello, I am a panel from {{ project_name }}{% endblocktrans %}</span>
 </li>

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -11,13 +11,15 @@ This project was created from the [cookiecutter-wagtail-package](https://github.
 ## Key commands
 
 ```sh
-just help        # View all commands
-just install     # Install Python and Node.js dependencies
-just demo        # Run the demo Wagtail site (migrate + load data + runserver)
-just test        # Run tests with pytest
-just lint        # Run all linters (Ruff, prek, Prettier, Stylelint)
-just format      # Run all formatters (Ruff, Prettier)
-just coverage    # Run tests with coverage report
+just help            # View all commands
+just install         # Install Python and Node.js dependencies
+just demo            # Run the demo Wagtail site (migrate + load data + runserver)
+just test            # Run tests with pytest
+just lint            # Run all linters (Ruff, pre-commit, Prettier, Stylelint)
+just format          # Run all formatters (Ruff, Prettier)
+just coverage        # Run tests with coverage report
+just makemessages    # Extract messages for translation
+just compilemessages # Compile translation message catalogs for use
 ```
 
 ## Quality assurance

--- a/template/CONTRIBUTING.md
+++ b/template/CONTRIBUTING.md
@@ -65,6 +65,49 @@ There is also a nightly job that tests against the latest development version of
 
 Create a pull request with your changes so that it can be code reviewed by a maintainer. Ensure that you give a summary with the purpose of the change and any steps that the reviewer needs to take to test your work. Please make sure to provide unit tests for your work.
 
+## Translating
+
+Translations are managed using [Django's built-in internationalization framework](https://docs.djangoproject.com/en/6.1/topics/i18n/translation/). The translation files are located in the `src/my_project_name/locale/` directory of the project.
+
+### Authoring guidance for new strings
+
+When adding new translatable strings, use appropriate translation functions in your code. Such as `ngettext` to support pluralization or `pgettext` for context-specific translations. Use `{% raw %}{% blocktrans trimmed %}{% endraw %}` in templates for multi-line strings. The `trimmed` option removes leading and trailing whitespace from the translated string.
+
+Principles for writing translatable strings:
+
+- **Use decent English:** When a string is written in poor English or is ambiguous, it is hard to understand and translate. Include a `# Translators: ...` comment above the string to clarify the meaning if needed. Ask yourself: "If I were a translator, would I understand this string and how it is used in isolation? Do I need to provide additional context?"
+- **Entire sentences:** Ensure that each translatable string is a complete sentence. Avoid interpolating or concatenating strings with verbs and nouns to form sentences. This makes it difficult to understand and create grammatically appropriate translations for every scenario.
+- **Prefer named placeholders:** When interpolating variables into translatable messages, use named placeholders instead of positional ones (`%(placeholder_name)s` instead of `%s`). This makes it easier for translators to understand the context and allows reordering placeholders as necessary.
+
+For detailed code examples, Wagtail's contribution guide has a section on [marking strings for translation](https://docs.wagtail.org/en/stable/contributing/translations.html#marking-strings-for-translation)
+
+### Updating all translations
+
+It isn't expected of contributors to update the translations after changing or adding new strings, since this often generates git conflicts with other contributors doing the same. If you do want to update all translations, run the following command:
+
+```sh
+just makemessages
+```
+
+### Adding a new language
+
+[Find your ISO-639 language code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) and run the following command to create a new translation catalog for your language:
+
+```sh
+just makemessages -l=<language_code>
+```
+
+After that, you can start translating the generated `src/my_project_name/locale/<language_code>/LC_MESSAGES/django.po` file. [POEdit](https://poedit.com/) is a popular tool for editing `.po` files.
+
+### Compiling translations
+
+By default the source code only contains the `.po` files, which are human-readable.
+If you want to make the translations available for use in the application, you need to compile them into `.mo` files. You can do this by running:
+
+```sh
+just compilemessages
+```
+
 ## Releases
 
 On the `main` branch:


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check CONTRIBUTING.md -->

<!-- Insert the issue number that you're fixing here, if any -->
Basic fix for #88 - there are more advanced integrations possible with translation services such as Weblate.

### Description

Adds support for translations along with some guiding documentation. The intent is that new/updated translations have to be contributed through pull requests.

Since gettext `.mo` files are generated binary files, they shouldn't be checked into git (in my opinion). They are build time artifacts.

<img width="1099" height="940" alt="Screenshot 2026-08-14 at 1 17 07 PM" src="https://github.com/user-attachments/assets/2f7b1d50-d9e8-4dcf-b972-7663454e2e0f" />


### AI usage

GitHub Copilot in my IDE for auto completions, mostly used for the contributing docs. All sample translations except the Dutch one are AI generated. Blame the machine – not me – if it made a poor translation 😇